### PR TITLE
Add documentation and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Including the below `yaml` in your `.travis.yml` and providing the
 
 ```yaml
 after_success:
+  - wget https://github.com/Michionlion/pr-tag-release/releases/latest/download/pr_tag_release.sh
   - source pr_tag_release.sh
 deploy:
   provider: releases


### PR DESCRIPTION
This release is a major update -- the first, actually.

PR Tag Release is a tool that can automatically create releases and increment semantically versioned tags by reading PR descriptions. For instance, that sentence above? It signals to the script that this PR description should actually be the release description of a major version update -- `v1.0.0`.
The various regular expressions that determine which version a particular description falls under (or if it falls under any) are completely user configurable, by changing environment variables.

All of this is detailed in the `README.md` included in the repository. An example `.travis.yml` for uploading files to the created releases is also given; while we depend on Travis for some convenience environmental variables, it would be easy to adapt this tool for any build environment.

If you have any questions, feel free to contact the maintainer, @Michionlion!