### PR TITLE
Fix ordering bug and failed release [DRAFT]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the Pull Request, unlike the others, which apply to the body.
 ```bash
 DEPLOY_BRANCH=${DEPOY_BRANCH-"^master$"}
 MERGE_COMMIT_REGEX=${MERGE_COMMIT_REGEX-"Merge pull request #([0-9]+)"}
-PATCH_CHANGE_REGEX=${PATCH_CHANGE_REGEX-"This (PR|release) is an?( small| tiny)? (update|bugfix)"}
+PATCH_CHANGE_REGEX=${PATCH_CHANGE_REGEX-"This (PR|release) is an?( small| tiny)? (update|bugfix|change)"}
 MINOR_CHANGE_REGEX=${MINOR_CHANGE_REGEX-"This (PR|release) is a (feature( update| change)?|big (update|change))"}
 MAJOR_CHANGE_REGEX=${MAJOR_CHANGE_REGEX-"This (PR|release) (is a ((compatibility[ -])?breaking|major) (update|change)| breaks( backwards)? compatibility)"}
 PRERELEASE_REGEX=${PRERELEASE_REGEX-"\[(PRE|WIP|PRERELEASE)\]"}

--- a/pr_tag_release.sh
+++ b/pr_tag_release.sh
@@ -7,7 +7,7 @@
 
 DEPLOY_BRANCH=${DEPOY_BRANCH-"^master$"}
 MERGE_COMMIT_REGEX=${MERGE_COMMIT_REGEX-"Merge pull request #([0-9]+)"}
-PATCH_CHANGE_REGEX=${PATCH_CHANGE_REGEX-"This (PR|release) is an?( small| tiny)? (update|bugfix)"}
+PATCH_CHANGE_REGEX=${PATCH_CHANGE_REGEX-"This (PR|release) is an?( small| tiny)? (update|bugfix|change)"}
 MINOR_CHANGE_REGEX=${MINOR_CHANGE_REGEX-"This (PR|release) is a (feature( update| change)?|big (update|change))"}
 MAJOR_CHANGE_REGEX=${MAJOR_CHANGE_REGEX-"This (PR|release) (is a ((compatibility[ -])?breaking|major) (update|change)| breaks( backwards)? compatibility)"}
 PRERELEASE_REGEX=${PRERELEASE_REGEX-"\[(PRE|WIP|PRERELEASE)\]"}

--- a/pr_tag_release.sh
+++ b/pr_tag_release.sh
@@ -229,9 +229,9 @@ status
 export_pr_num || return 0
 check_valid_state || return 0
 export_pr_info || return 0
-update_version || return 0
 
 create_release_body
+update_version || return 0
 
 set_up_git
 create_version_tag || return 0


### PR DESCRIPTION
This release is a small change -- well, a few actually. First, the PR description is now printed before determining what type of change it is. Second, the default regular expression for patch versions was updated. Lastly, the example Travis CI configuration from `README.md` was added to our actual `.travis.yml`.